### PR TITLE
Update Porsche 981 Cayman generations: Verified generation data from Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# Porsche 981 Cayman
+
+This repository contains signal set configurations for the Porsche 981 Cayman, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Porsche 981 Cayman.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Porsche_Cayman"
+
 generations:
   - name: "981 Generation"
     start_year: 2013


### PR DESCRIPTION
- Confirmed single 981 generation (2013-2016) from Porsche Cayman Wikipedia article
- Added references array with Wikipedia citation
- Updated README.md with standard template
- Generation data accurate: Cayman released as 2014 model in spring 2013, ran through 2016
